### PR TITLE
Fix: Update FontLoader import and usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,6 @@
 
 
     <!-- Our script -->
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,4 @@
+import { FontLoader } from 'three/examples/jsm/loaders/FontLoader.js';
 // Ensure script runs after HTML is loaded
 document.addEventListener('DOMContentLoaded', () => {
     // DOM Elements
@@ -51,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- three.js Setup ---
     let scene, camera, renderer, controls;
     const loader = new THREE.GLTFLoader();
-    const fontLoader = new THREE.FontLoader();
+    const fontLoader = new FontLoader();
 
     function initThreeJS() {
         scene = new THREE.Scene();


### PR DESCRIPTION
FontLoader was removed from the THREE namespace in r133. This commit updates the code to import FontLoader from 'three/examples/jsm/loaders/FontLoader.js' and instantiates it directly.

The script tag for script.js in index.html has also been updated to type="module" to support ES module imports.